### PR TITLE
Fix mobile view to let users select chat instead of auto-switching to…

### DIFF
--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -178,15 +178,14 @@ const HomePage = () => {
 
       if (scadCode) {
           store.setOriginalCode(scadCode);
-          store.setCode(scadCode); 
+          store.setCode(scadCode);
           if (typeof store.setParameters === 'function') {
-            store.setParameters([]); 
-            if (params.length > 0) store.setParameters(params); 
+            store.setParameters([]);
+            if (params.length > 0) store.setParameters(params);
           }
       }
-      
+
       fetchModelFiles(updatedShape);
-      if (window.innerWidth < 1024) setMobilePanel('viewer');
       return;
     }
 
@@ -198,12 +197,13 @@ const HomePage = () => {
                 
         if (scadCode) {
             store.setOriginalCode(scadCode);
-            store.setCode(scadCode); 
+            store.setCode(scadCode);
             if (typeof store.setParameters === 'function') {
-              store.setParameters([]); 
-              if (params.length > 0) store.setParameters(params); 
+              store.setParameters([]);
+              if (params.length > 0) store.setParameters(params);
             }
-            if (activeView !== 'editor') setActiveView('editor');
+            // Desktop: auto-switch to editor. Mobile: respect user's panel choice
+            if (activeView !== 'editor' && window.innerWidth >= 1024) setActiveView('editor');
         }
         return;
     }
@@ -217,20 +217,19 @@ const HomePage = () => {
         
         if (scadCode) {
             store.setOriginalCode(scadCode);
-            store.setCode(scadCode); 
+            store.setCode(scadCode);
             if (typeof store.setParameters === 'function') {
-              store.setParameters([]); 
-              if (params.length > 0) store.setParameters(params); 
+              store.setParameters([]);
+              if (params.length > 0) store.setParameters(params);
             }
-            if (activeView !== 'editor') setActiveView('editor');
+            // Desktop: auto-switch to editor. Mobile: respect user's panel choice
+            if (activeView !== 'editor' && window.innerWidth >= 1024) setActiveView('editor');
         }
-        
+
         if (shape.sdfUrl && updatedShape) {
             fetchModelFiles(updatedShape);
         }
     }
-    
-    if (window.innerWidth < 1024) setMobilePanel('viewer');
   }, [fetchModelFiles, modelCache, setActiveView, setMobilePanel, activeView]);
   
   const handleImportComplete = useCallback((shape: GeneratedShape, group: THREE.Group) => {


### PR DESCRIPTION
… editor

Mobile users couldn't select conversations because the app automatically switched to the viewer/editor panel whenever a shape loaded from chat history. This prevented users from staying in the chat panel to select a conversation.

The fix:
- Remove automatic panel switches on mobile (mobilePanel stays user-controlled)
- Keep desktop behavior: auto-switch to editor when shape loads
- Mobile behavior: respect user's panel choice and let them decide when to view/edit the loaded shape

Now mobile users start in the chat panel and can manually navigate to other panels (viewer/editor) as needed.